### PR TITLE
Add logs in _get_url_type to correct return value

### DIFF
--- a/server.py
+++ b/server.py
@@ -117,13 +117,15 @@ def handle_playlist(playlist_url:str):
 
 def _get_url_type(url:str):
     try:
-        pytube.Playlist(url)
+        playlist = pytube.Playlist(url)
+        logging.info(f"{url} is a playlist with {len(playlist)} videos")
         return UrlType.PLAYLIST
     except:
         try:
             pytube.YouTube(url)
             return UrlType.VIDEO
         except:
+            logging.error(f"url {url} is not a playlist or video!")
             return UrlType.UNKNOWN
 
 
@@ -145,10 +147,11 @@ async def play(url: str):
     
     # Start thread to download video, stream it, and provide a response
     try:
+        url_type = _get_url_type(url)
         # Check if the given url is a valid video or playlist
-        if _get_url_type(url) == UrlType.VIDEO:
+        if url_type == UrlType.VIDEO:
             threading.Thread(target=handle_play, args=(url,)).start()
-        elif _get_url_type(url) == UrlType.PLAYLIST:
+        elif url_type == UrlType.PLAYLIST:
             if len(Playlist(url)) == 0:
                 raise Exception("This playlist url is invalid. Playlist may be empty or no longer exists.")
             threading.Thread(target=handle_playlist, args=(url,)).start()


### PR DESCRIPTION
we rely on a URL raising an error if it's a video and not a playlist. however the error not raised by simply calling `pytube.Playlist`. by logging the length of the potential playlist, an error is raised if the URL isnt the playlist. if it is, we get a helpful log to show the url and how many videos it has


resolves the below error
![image](https://github.com/SCE-Development/sce-tv/assets/36345325/0b738f55-b961-45ed-81d7-6aac042aeeb2)
