### PR TITLE
delete str in debug endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -216,8 +216,8 @@ def debug():
     return {
 
             "state": {
-                "process_dict": str(process_dict),
-                "current_video_dict": str(current_video_dict)
+                "process_dict": process_dict,
+                "current_video_dict": current_video_dict
                     },
             "cache": vars(video_cache)
             }


### PR DESCRIPTION
Removed the str() function for displaying `process_dict` and `current_video_dict`.