### PR TITLE
Fixed stop button visibility changes

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -75,6 +75,9 @@
                 playButton.textContent = "Success!";
                 playButton.disabled = true;
                 document.getElementById("playing").style.display = "block";
+                //Manually upate the interlude and stop button, or else it won't update unless page is reloaded
+                document.getElementById("interlude").style.visibility = "hidden";
+                document.getElementById("playing").style.visibility="visible";
                 setTimeout(() => {
                     playButton.textContent = "Play";
                     playButton.disabled = false;

--- a/static/index.html
+++ b/static/index.html
@@ -11,7 +11,7 @@
 <body>
     <div style="text-align: center;">
         <h2 style="text-align: center; color: white;" id="cache_tag" >SCE TV</h2>
-        <div id="interlude">
+        <div id="urlInput">
             <input type="text" id="url" onchange="OnUrlChange(event, true)" placeholder="PASTE A YOUTUBE LINK FOR EPICNESS">
             <select id="resolution">
                 <option value="144">144p</option>
@@ -75,8 +75,8 @@
                 playButton.textContent = "Success!";
                 playButton.disabled = true;
                 document.getElementById("playing").style.display = "block";
-                //Manually upate the interlude and stop button, or else it won't update unless page is reloaded
-                document.getElementById("interlude").style.visibility = "hidden";
+                //Manually upate the urlInput and stop button, or else it won't update unless page is reloaded
+                document.getElementById("urlInput").style.visibility = "hidden";
                 document.getElementById("playing").style.visibility="visible";
                 setTimeout(() => {
                     playButton.textContent = "Play";
@@ -91,14 +91,14 @@
         async function Stop(e) {
             e.preventDefault();
             await fetch(stopURL.href, { method: "POST" });
-            document.getElementById("interlude").style.visibility = "visible";
+            document.getElementById("urlInput").style.visibility = "visible";
             document.getElementById("metadata").style.visibility = "hidden";
             document.getElementById("playing").style.display = "none";
         }
         fetch(stateURL.href).then((response) => response.json()).then((json) => {
             const state = json["state"];
             if (state === "playing") {
-                document.getElementById("interlude").style.visibility = "hidden";
+                document.getElementById("urlInput").style.visibility = "hidden";
 				document.getElementById("playing").style.visibility = "visible";
                 document.getElementById('title').innerHTML = json["nowPlaying"]["title"];
                 document.getElementById('thumbnail').src = json["nowPlaying"]["thumbnail"]
@@ -156,7 +156,7 @@
             else {
                 document.getElementById("metadata").style.visibility = "visible";
                 document.getElementById("playing").style.display = "block";
-                document.getElementById("interlude").style.visibility = "hidden";
+                document.getElementById("urlInput").style.visibility = "hidden";
                 document.getElementById('title').innerHTML = json["nowPlaying"]["title"];
                 document.getElementById('thumbnail').src = json["nowPlaying"]["thumbnail"]
             }


### PR DESCRIPTION
Before, when you clicked play, it wouldn't show the stop button and the search bar would still be there. I just manually changed it so that 'urlInput' and 'playing' would either appear or disappear accordingly

<img width="983" height="784" alt="image" src="https://github.com/user-attachments/assets/398204eb-47d8-4458-b26a-77935afd051a" />
With the new changes, it immediately updates the page to this screen. 

<img width="865" height="789" alt="image" src="https://github.com/user-attachments/assets/73cce604-49b3-499a-afcf-c253992c4c2e" />
Before, this is what you would see after pressing the play button, unless you reloaded the page.




