### PR TITLE
fixed typo from strderr to stderr

### DIFF
--- a/server.py
+++ b/server.py
@@ -134,7 +134,7 @@ def create_ffmpeg_stream(
         command[2:2] = ["-stream_loop", "-1"]
     process = subprocess.Popen(
         command,
-        strderr=None,
+        stderr=None,
         stdout=None,
         text=True,
         bufsize=1,


### PR DESCRIPTION
Fixed a typo: `strderr` → `stderr`