### PR TITLE
add debug button

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -71,6 +71,17 @@ input {
     margin-left: 10px;
 }
 
+#debug-btn{
+    height: 2.2em; 
+    background-color: orange; 
+    color: white; 
+    border: none; 
+    border-radius: 4px; 
+    padding: 8px 16px; 
+    cursor: pointer; 
+    margin-left: 10px;
+}
+
 .card {
     background: hsla(0, 0%, 31%, 0.7);
     border-radius: 12px;

--- a/static/index.html
+++ b/static/index.html
@@ -220,7 +220,10 @@
 
         // Adds a function to open the debug page in a new window when the debug button is clicked
         document.getElementById("debug-btn").addEventListener("click", function () {
-            const debugURL = new URL(window.location.href + (window.location.href.endsWith('/') ? "" : "/") + "debug")
+            const debugURL = new URL(window.location.origin + window.location.pathname);
+            debugURL.pathname = debugURL.pathname.endsWith('/') 
+            ? `${debugURL.pathname}debug` 
+            : `${debugURL.pathname}/debug`;
             window.open(debugURL);
         });
     </script>

--- a/static/index.html
+++ b/static/index.html
@@ -220,7 +220,7 @@
 
         // Adds a function to open the debug page in a new window when the debug button is clicked
         document.getElementById("debug-btn").addEventListener("click", function () {
-            let debugURL = new URL(window.location.href + "debug")
+            const debugURL = new URL(window.location.href + (window.location.href.endsWith('/') ? "" : "/") + "debug")
             window.open(debugURL);
         });
     </script>

--- a/static/index.html
+++ b/static/index.html
@@ -16,9 +16,12 @@
         </div>
         <div class="card">
             <div style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
-                <div style="display: flex; justify-content: center; align-items: center; padding-bottom: 10px;">
+                <div style="display: flex; justify-content: center; align-items: center; padding-bottom: 5px;">
                     <h2 id="cache_tag">SCE TV</h2>
+                </div>
+                <div style="display: flex; justify-content: center; align-items: center; padding-bottom: 10px;">
                     <button id="show-logs-btn">Show Logs</button>
+                    <button id="debug-btn">Debug</button>
                 </div>
             </div>
 
@@ -214,6 +217,12 @@
             // Scroll to bottom
             logsContent.scrollTop = logsContent.scrollHeight;
         }
+
+        // Adds a function to open the debug page in a new window when the debug button is clicked
+        document.getElementById("debug-btn").addEventListener("click", function () {
+            let debugURL = new URL(window.location.href + "debug")
+            window.open(debugURL);
+        });
     </script>
 </body>
 


### PR DESCRIPTION
resolves #83
- moves the "Show Logs" button beneath the SCE TV header
- adds a debug button that, when clicked, opens a new window that displays the /debug endpoint
 
desktop:
<img width="777" height="217" alt="updated" src="https://github.com/user-attachments/assets/61e96ddd-9e13-4f1e-9d96-016113da75ac" />
mobile:
<img width="322" height="699" alt="localhost_5001_(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/9e8e0d45-2e2f-497a-be71-d5e83cf7662d" />
