### PR TITLE
update cache file frequently

### DIFF
--- a/modules/cache.py
+++ b/modules/cache.py
@@ -80,6 +80,8 @@ class Cache:
         self.current_size_bytes += video_info.size_bytes
         MetricsHandler.cache_size.set(len(self.video_id_to_path))
         MetricsHandler.cache_size_bytes.set(self.current_size_bytes)
+        if self.cache_file:
+            self.write_cache()
 
     def find(self, video_id: str):
         if video_id in self.video_id_to_path:

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -99,6 +99,8 @@ class Cache:
             removed_video_info = self.video_id_to_path.popitem(last=False)[1]
             self.current_size_bytes -= removed_video_info.size_bytes
             os.remove(removed_video_info.file_path)
+        if self.cache_file:
+            self.write_cache()
 
     def clear(self):
         self._downsize_cache_to_target_bytes(0)


### PR DESCRIPTION
If a cache file is specified, it is only updated when the server shuts down. At times, the server is unable to perform a graceful shutdown, preventing the cache file on disk from updating and rendering new videos played during the server's uptime inaccessible. To circumvent this, we update the cache file (if it exists) whenever a new video is added, instead of when the server shuts down.