### PR TITLE
fix file naming issue

### DIFF
--- a/modules/cache.py
+++ b/modules/cache.py
@@ -57,18 +57,13 @@ class Cache:
             self._downsize_cache_to_target_bytes(target_bytes)
             MetricsHandler.cache_size.set(len(self.video_id_to_path))
             MetricsHandler.cache_size_bytes.set(self.current_size_bytes)
-        video_file_name = video.default_filename
+        video_file_name = str(uuid.uuid4()) + ".mp4"
         with MetricsHandler.download_time.time():
-            video.download(self.file_path)
+            video.download(self.file_path, filename=video_file_name)
         MetricsHandler.data_downloaded.inc(video.filesize)
         MetricsHandler.video_download_count.inc()
         video_id = self.get_video_id(url)
-        video_file_name = str(uuid.uuid4()) + ".mp4"
         video_file_path = os.path.join(self.file_path, video_file_name)
-        os.rename(
-            os.path.join(self.file_path, video.default_filename),
-            video_file_path,
-        )
         logging.info(f"downloaded {url} to path {video_file_path}")
         video_info = VideoInfo(
             file_path=video_file_path,


### PR DESCRIPTION
downloading a video with characters in the title that are disallowed in a file name results in `video.default_filename` differing from the name of the file on disk (see below). this PR instead uses pytubefix's built-in `filename` parameter to create a file with the desired file name.

file name includes the '/' 
<img width="904" height="238" alt="ss1" src="https://github.com/user-attachments/assets/480ef6a3-b9e7-46c1-ae15-64e0f6eb31cd" />

no '/'
<img width="129" height="175" alt="SS2" src="https://github.com/user-attachments/assets/841fc36f-8325-4fa9-bd76-abc97a621f29" />