### PR TITLE
Fix form not appearing on page reload when a video is playing

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -167,7 +167,7 @@
         fetch(stateURL.href).then((response) => response.json()).then((json) => {
             const state = json["state"];
             if (state === "playing") {
-                document.getElementById("urlInput").style.visibility = "hidden";
+                document.getElementById("urlInput").style.visibility = "visible";
                 document.getElementById("playing").style.visibility = "visible";
                 document.getElementById('title').innerHTML = json["nowPlaying"]["title"];
                 document.getElementById('thumbnail').src = json["nowPlaying"]["thumbnail"]


### PR DESCRIPTION
Before:
<img width="749" height="928" alt="image" src="https://github.com/user-attachments/assets/04c6e55f-6a65-427e-b7f7-8b6b71c855fc" />

After:
<img width="831" height="933" alt="image" src="https://github.com/user-attachments/assets/50ce2da7-51d4-4d4a-bd74-36f90fbd06e0" />
