### PR TITLE
add delete from cache button

### DIFF
--- a/modules/cache.py
+++ b/modules/cache.py
@@ -96,6 +96,12 @@ class Cache:
             os.remove(removed_video_info.file_path)
         if self.cache_file:
             self.write_cache()
+    
+    def delete(self, id: str):
+        removed_video_info = self.video_id_to_path.pop(id)
+        self.write_cache()
+        self.current_size_bytes -= removed_video_info.size_bytes
+        os.remove(removed_video_info.file_path)
 
     def clear(self):
         self._downsize_cache_to_target_bytes(0)

--- a/server.py
+++ b/server.py
@@ -150,6 +150,7 @@ def create_ffmpeg_stream(
     if None not in [title, thumbnail]:
         current_video_dict["title"] = title
         current_video_dict["thumbnail"] = thumbnail
+        current_video_dict["file_path"] = file_path
 
     logging.info(f"process {process.pid} started for {video_type.value} video: {file_path}")
     process_dict[video_type] = process.pid
@@ -350,6 +351,7 @@ def handle_cache_play(repeat: bool = False):
             # Store the current playing video information
             current_video_dict["title"] = video.title
             current_video_dict["thumbnail"] = video.thumbnail
+            current_video_dict["file_path"] = video.file_path
 
             # Get the file path of the video to stream
             file_path = video.file_path
@@ -520,7 +522,17 @@ async def play(url: str, loop: bool = False, repeat: bool = False):
     except Exception:
         logging.exception('unable to play video from url')
         raise HTTPException(status_code=500, detail="check logs")
-    
+
+
+@app.post("/delete/file")
+async def delete_file(id: str):
+    try:
+        video_cache.delete(id)
+        return {"detail": "Success"}
+    except Exception:
+        logging.exception('unable to delete file from cache')
+        raise HTTPException(status_code=500, detail="check logs")
+
 
 @app.get("/metadata")
 def metadata(url: str):

--- a/static/cache.css
+++ b/static/cache.css
@@ -2,7 +2,7 @@ body {
   overflow-x: hidden;
 }
 #videoContainer {
-  width: 50%;
+  width: 60%;
   height: 100px;
   border: 1px solid #ccc;
   display: flex;
@@ -43,4 +43,10 @@ body {
 }
 .playButton {
   width: 10%;
+}
+.deleteButton {
+  width: 12%;
+}
+.delete-clicked {
+  background-color: #f06565;
 }

--- a/static/cache.html
+++ b/static/cache.html
@@ -40,6 +40,19 @@
                   } 
             }
 
+          async function deleteVideo(e, video) {
+            try {
+              e.preventDefault();
+              const file_path = video.path;
+              let url = new URL("delete/file", window.location.href);
+              url.searchParams.append("id", video.id);
+              const response = await fetch(url.href, { method: "POST" });
+              return response.json();
+            } catch(error) {
+              console.log(error);
+            } 
+          }
+
           async function togglePlayEntireDirectory(e) {
             try {
               e.preventDefault()
@@ -69,22 +82,41 @@
             }  
           }
 
-          async function handlePlayButton(e, video) {
+          async function handlePlayButton(e, video, deleteButton) {
             const playButton = document.getElementById(video.id)
             const response = await togglePlayVideo(e, video)
             if (response["detail"] === "Success") {
             playButton.textContent = "Success!";
             playButton.disabled = true;
+            deleteButton.disabled = true;
             
             setTimeout(() => {
-              playButton.textContent = "Play";
+              playButton.textContent = "play";
               playButton.disabled = false;
             }, 2000);
           } else {
             alert(response["detail"]);
           }  
         }
-z
+          
+          async function handleDeleteButton(e, video, deleteButton, videoContainer) {
+            if (!deleteButton.classList.contains("delete-clicked")) {
+              deleteButton.classList.add("delete-clicked");
+              deleteButton.textContent = "confirm deletion?";
+              setTimeout(() => {
+                deleteButton.textContent = "delete";
+                deleteButton.classList.remove("delete-clicked");
+              }, 2000);
+            } else {
+              const response = await deleteVideo(e, video);
+              if (response["detail"] === "Success") {
+                videoContainer.remove();
+              } else {
+                alert(response["detail"]);
+              }
+            }
+          }
+
           function formatBytes(bytes) {
             if (bytes === 0) return '0 bytes';
             const sizes = ['bytes', 'kb', 'mb', 'gb', 'tb'];
@@ -114,47 +146,70 @@ z
               console.log("No videos found")
               document.getElementById('playEntireDirectoryBtn').disabled = true;
             }
-            // Loop through each element in the object and render it on the screen
-            for (const element of returnedObject) {
-              const listOfVideosContainer = document.getElementById('listOfVideosContainer');
-              const videoContainer = document.createElement('div');
-              const videoImgContainer = document.createElement('div');
-              const videoTitleContainer = document.createElement('div');
-              const videoImg = document.createElement('img');
-              const videoTitle = document.createElement('p');
-              const playButton = document.createElement('button');
-              const videoSize = document.createElement('span');
-              const playEntireDirectoryBtn = document.getElementById('playEntireDirectoryBtn');
+            // Fetch the state to determine which video is currently playing
+            let currentVideoPath;
+            const baseURL = window.location.href.substring(0, window.location.href.lastIndexOf('/'));
+            const stateURL = new URL(baseURL + "/state", window.location.origin);
+            fetch(stateURL.href).then((response) => response.json()).then((json) => {
+              const state = json["state"];
+              if (state === "playing") {
+                currentVideoPath = json["nowPlaying"]["file_path"];
+              }
+            }).then( () => {
+              // Loop through each element in the object and render it on the screen
+              for (const element of returnedObject) {
+                const listOfVideosContainer = document.getElementById('listOfVideosContainer');
+                const videoContainer = document.createElement('div');
+                const videoImgContainer = document.createElement('div');
+                const videoTitleContainer = document.createElement('div');
+                const videoImg = document.createElement('img');
+                const videoTitle = document.createElement('p');
+                const playButton = document.createElement('button');
+                const deleteButton = document.createElement('button');
+                const videoSize = document.createElement('span');
+                const playEntireDirectoryBtn = document.getElementById('playEntireDirectoryBtn');
 
-              videoContainer.id = "videoContainer";
-              videoImgContainer.id = "videoImgContainer";
-              videoTitleContainer.id = "videoTitleContainer";
-              playButton.id = element.id;
-              playButton.className = "playButton";
-              videoSize.className = "videoSize";
+                videoContainer.id = "videoContainer";
+                videoImgContainer.id = "videoImgContainer";
+                videoTitleContainer.id = "videoTitleContainer";
+                playButton.id = element.id;
+                playButton.className = "playButton";
+                deleteButton.className = "deleteButton";
+                videoSize.className = "videoSize";
 
-              videoTitle.textContent = element.name;
-              videoImg.src = element.thumbnail;
-              videoImg.alt = "thumbnail";
-              playButton.textContent = 'play';
-              videoSize.textContent = formatBytes(element.size_bytes);
-        
-              playButton.addEventListener('click', (e) => {
-                handlePlayButton(e, element)
-              });
+                videoTitle.textContent = element.name;
+                videoImg.src = element.thumbnail;
+                videoImg.alt = "thumbnail";
+                playButton.textContent = 'play';
+                deleteButton.textContent = 'delete';
+                videoSize.textContent = formatBytes(element.size_bytes);
+                
+                if (element.path === currentVideoPath) {
+                  deleteButton.disabled = true;
+                }
+          
+                playButton.addEventListener('click', (e) => {
+                  handlePlayButton(e, element, deleteButton);
+                });
 
-              playEntireDirectoryBtn.addEventListener('click', handlePlayEntireDirectoryButton);
+                deleteButton.addEventListener('click', (e) => {
+                  handleDeleteButton(e, element, deleteButton, videoContainer);
+                });
 
-              videoImgContainer.appendChild(videoImg);
-              videoTitleContainer.appendChild(videoTitle);
-              videoContainer.appendChild(videoImgContainer);
-              videoContainer.appendChild(videoTitleContainer);
-              videoContainer.appendChild(videoSize);
-              videoContainer.appendChild(playButton);
-              listOfVideosContainer.appendChild(videoContainer);
+                playEntireDirectoryBtn.addEventListener('click', handlePlayEntireDirectoryButton);
 
-              
-        }}
+                videoImgContainer.appendChild(videoImg);
+                videoTitleContainer.appendChild(videoTitle);
+                videoContainer.appendChild(videoImgContainer);
+                videoContainer.appendChild(videoTitleContainer);
+                videoContainer.appendChild(videoSize);
+                videoContainer.appendChild(playButton);
+                videoContainer.appendChild(deleteButton);
+                listOfVideosContainer.appendChild(videoContainer);
+    
+              }
+            })
+          }
   </script>
   
   <script>

--- a/static/cache.html
+++ b/static/cache.html
@@ -112,6 +112,9 @@
               if (response["detail"] === "Success") {
                 videoContainer.remove();
                 handleBytes();
+                if (document.getElementById('listOfVideosContainer').childElementCount === 0) {
+                  document.getElementById('playEntireDirectoryBtn').disabled = true;
+                }
               } else {
                 alert(response["detail"]);
               }

--- a/static/cache.html
+++ b/static/cache.html
@@ -111,6 +111,7 @@
               const response = await deleteVideo(e, video);
               if (response["detail"] === "Success") {
                 videoContainer.remove();
+                handleBytes();
               } else {
                 alert(response["detail"]);
               }


### PR DESCRIPTION
resolves #81
- adds a "delete" button on the cache page
- can only delete videos that aren't currently playing
- deleting a video updates the html and cache file immediately

delete button:
<img width="1157" height="503" alt="image" src="https://github.com/user-attachments/assets/7716c1e1-8bb3-4d59-ab37-7f66d045c30d" />

if a video is playing:
<img width="1155" height="509" alt="image" src="https://github.com/user-attachments/assets/054e1034-b06a-44ba-9232-40aa40828b9c" />

when clicked once:
<img width="1160" height="514" alt="image" src="https://github.com/user-attachments/assets/9de89db7-60bb-4fbb-aea7-af05fba06f3c" />

after deletion:
<img width="1142" height="406" alt="image" src="https://github.com/user-attachments/assets/e14dac69-be93-4063-a1b0-af47a2ced11a" />