### PR TITLE
PI code for weather idle screen for when the tv is not in use

### DIFF
--- a/receive.py
+++ b/receive.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 import queue
 import threading
 import time
@@ -20,8 +21,8 @@ def get_stream_state(ip, port=5001, timeout=5):
         with urllib.request.urlopen(url, timeout=timeout) as response:
             data = json.loads(response.read())
         return "playing" if data.get("state") == "playing" else "idle"
-    except Exception as e:
-        print(f"Could not reach sce-tv server at {url}: {e}")
+    except Exception:
+        logging.exception("Could not reach sce-tv server at %s", url)
         return None
 
 def receive_stream(instance, player, urls):

--- a/receive.py
+++ b/receive.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+import threading
+import time
+import urllib.request
+from urllib.parse import urlparse
+import vlc
+
+# Set when the sce-tv server reports "idle", cleared when it is "playing"
+idle_event = threading.Event()
+
+def get_stream_state(ip, port=5001, interval=5):
+
+    # Continuously ask the sce-tv server at the given IP for the current state, "idle" or "playing"
+    url = f"http://{ip}:{port}/state"
+    while True:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                data = json.loads(response.read())
+            state = "playing" if data.get("state") == "playing" else "idle"
+            print(f"sce-tv state: {state}")
+            if state == "idle":
+                idle_event.set()
+            else:
+                idle_event.clear()
+        except Exception as e:
+            print(f"Could not reach sce-tv server at {url}: {e}")
+        time.sleep(interval)
+
+def play_stream(url):
+    instance = vlc.Instance()
+    player = instance.media_player_new()
+
+    switch_stream(instance, player, url)
+    print("Starting playback...")
+
+    # Buffer
+    time.sleep(5)
+
+    return instance, player
+
+def switch_stream(instance, player, url):
+    media = instance.media_new(url)
+    player.set_media(media)
+    player.play()
+
+def stream_switcher(instance, player, sce_tv_url, weather_url):
+
+    # Swap the active stream depending on playing state
+    # idle: weather channel, playing: sce-tv
+    while True:
+        # Block until the server reports idle, then switch to weather
+        idle_event.wait()
+        print("sce-tv idle, switching to the weather channel...")
+        switch_stream(instance, player, weather_url)
+
+        # Block until the server is playing, then switch to sce-tv
+        while idle_event.is_set():
+            time.sleep(1)
+        print("sce-tv playing, switching back to sce-tv...")
+        switch_stream(instance, player, sce_tv_url)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sce-tv-rtmp-url",
+        required=True,
+        help="RTMP stream URL (e.g. rtmp://server/live/streamkey)"
+    )
+    parser.add_argument(
+        "--weather-rtmp-url",
+        help="weather channel RTMP stream URL (e.g. rtmp://server/live/weather)"
+    )
+    args = parser.parse_args()
+
+    # State API runs on the same host as the RTMP server, so derive it from the stream URL rather than passing the host separately
+    sce_tv_ip = urlparse(args.sce_tv_rtmp_url).hostname
+
+    state_thread = threading.Thread(
+        target=get_stream_state,
+        args=(sce_tv_ip,),
+        daemon=True,
+    )
+    state_thread.start()
+
+    instance, player = play_stream(args.sce_tv_rtmp_url)
+
+    # Only enable idle-based switching when a weather channel URL is provided
+    if args.weather_rtmp_url:
+        switcher_thread = threading.Thread(
+            target=stream_switcher,
+            args=(instance, player, args.sce_tv_rtmp_url, args.weather_rtmp_url),
+            daemon=True,
+        )
+        switcher_thread.start()
+
+    while True:
+        time.sleep(1)

--- a/receive.py
+++ b/receive.py
@@ -64,6 +64,13 @@ def signal(ip, weather_url, interval=5):
         time.sleep(interval)
 
 if __name__ == "__main__":
+    logging.Formatter.converter = time.gmtime
+
+    logging.basicConfig(
+        format="%(asctime)s.%(msecs)03dZ %(levelname)s:%(name)s:%(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+        level=logging.ERROR
+    )
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--sce-tv-rtmp-url",

--- a/receive.py
+++ b/receive.py
@@ -30,7 +30,7 @@ def receive_stream(instance, player, urls):
     media = instance.media_new(urls[receive_sce_tv])
     player.set_media(media)
     player.play()
-    print("Starting playback...")
+    logging.info("Starting playback...")
 
     # Buffer
     time.sleep(5)
@@ -39,7 +39,7 @@ def receive_stream(instance, player, urls):
     while True:
         command = commands.get()
         url = urls[command]
-        print(f"switching stream to {url}...")
+        logging.info("switching stream to %s...", url)
         media = instance.media_new(url)
         player.set_media(media)
         player.play()

--- a/receive.py
+++ b/receive.py
@@ -1,64 +1,66 @@
 import argparse
 import json
+import queue
 import threading
 import time
 import urllib.request
 from urllib.parse import urlparse
 import vlc
 
-# Set when the sce-tv server reports "idle", cleared when it is "playing"
-idle_event = threading.Event()
+receive_weather = threading.Event()
+receive_sce_tv = threading.Event()
 
-def get_stream_state(ip, port=5001, interval=5):
+commands = queue.Queue()
 
-    # Continuously ask the sce-tv server at the given IP for the current state, "idle" or "playing"
+def get_stream_state(ip, port=5001, timeout=5):
+
+    # Ask the sce-tv server at the given IP for the current state, "idle" or "playing"
     url = f"http://{ip}:{port}/state"
-    while True:
-        try:
-            with urllib.request.urlopen(url, timeout=5) as response:
-                data = json.loads(response.read())
-            state = "playing" if data.get("state") == "playing" else "idle"
-            print(f"sce-tv state: {state}")
-            if state == "idle":
-                idle_event.set()
-            else:
-                idle_event.clear()
-        except Exception as e:
-            print(f"Could not reach sce-tv server at {url}: {e}")
-        time.sleep(interval)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            data = json.loads(response.read())
+        return "playing" if data.get("state") == "playing" else "idle"
+    except Exception as e:
+        print(f"Could not reach sce-tv server at {url}: {e}")
+        return None
 
-def play_stream(url):
-    instance = vlc.Instance()
-    player = instance.media_player_new()
+def receive_stream(instance, player, urls):
 
-    switch_stream(instance, player, url)
+    media = instance.media_new(urls[receive_sce_tv])
+    player.set_media(media)
+    player.play()
     print("Starting playback...")
 
     # Buffer
     time.sleep(5)
 
-    return instance, player
-
-def switch_stream(instance, player, url):
-    media = instance.media_new(url)
-    player.set_media(media)
-    player.play()
-
-def work(instance, player, sce_tv_url, weather_url):
-
-    # Swap the active stream depending on playing state
-    # idle: weather channel, playing: sce-tv
+    # Consume state commands and switch the active stream to match
     while True:
-        # Block until the server reports idle, then switch to weather
-        idle_event.wait()
-        print("sce-tv idle, switching to the weather channel...")
-        switch_stream(instance, player, weather_url)
+        command = commands.get()
+        url = urls[command]
+        print(f"switching stream to {url}...")
+        media = instance.media_new(url)
+        player.set_media(media)
+        player.play()
 
-        # Block until the server is playing, then switch to sce-tv
-        while idle_event.is_set():
-            time.sleep(1)
-        print("sce-tv playing, switching back to sce-tv...")
-        switch_stream(instance, player, sce_tv_url)
+def signal(ip, weather_url, interval=5):
+
+    # Defaults to sce-tv, only switches to weather when server is idle and weather url is provided, pushes command when the state changes
+    while True:
+        state = get_stream_state(ip)
+
+        if weather_url and state == "idle":
+            target = receive_weather
+        else:
+            target = receive_sce_tv
+
+        if not target.is_set():
+            receive_weather.clear()
+            receive_sce_tv.clear()
+            target.set()
+            commands.put(target)
+
+        time.sleep(interval)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -76,23 +78,29 @@ if __name__ == "__main__":
     # State API runs on the same host as the RTMP server, so derive it from the stream URL rather than passing the host separately
     sce_tv_ip = urlparse(args.sce_tv_rtmp_url).hostname
 
-    state_thread = threading.Thread(
-        target=get_stream_state,
-        args=(sce_tv_ip,),
+    urls = {
+        receive_sce_tv: args.sce_tv_rtmp_url,
+        receive_weather: args.weather_rtmp_url,
+    }
+
+    receive_sce_tv.set()
+
+    instance = vlc.Instance()
+    player = instance.media_player_new()
+
+    receive_stream_thread = threading.Thread(
+        target=receive_stream,
+        args=(instance, player, urls),
         daemon=True,
     )
-    state_thread.start()
+    receive_stream_thread.start()
 
-    instance, player = play_stream(args.sce_tv_rtmp_url)
-
-    # Only enable idle-based switching when a weather channel URL is provided
-    if args.weather_rtmp_url:
-        switcher_thread = threading.Thread(
-            target=work,
-            args=(instance, player, args.sce_tv_rtmp_url, args.weather_rtmp_url),
-            daemon=True,
-        )
-        switcher_thread.start()
+    signal_thread = threading.Thread(
+        target=signal,
+        args=(sce_tv_ip, args.weather_rtmp_url),
+        daemon=True,
+    )
+    signal_thread.start()
 
     while True:
         time.sleep(1)

--- a/receive.py
+++ b/receive.py
@@ -44,7 +44,7 @@ def switch_stream(instance, player, url):
     player.set_media(media)
     player.play()
 
-def stream_switcher(instance, player, sce_tv_url, weather_url):
+def work(instance, player, sce_tv_url, weather_url):
 
     # Swap the active stream depending on playing state
     # idle: weather channel, playing: sce-tv
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     # Only enable idle-based switching when a weather channel URL is provided
     if args.weather_rtmp_url:
         switcher_thread = threading.Thread(
-            target=stream_switcher,
+            target=work,
             args=(instance, player, args.sce_tv_rtmp_url, args.weather_rtmp_url),
             daemon=True,
         )


### PR DESCRIPTION
Creates a receive.py client which switches the pi to play a weather channel when the tv is idle.

- get_stream_state function returns whether or not the player is "playing" or "idle". there is an idle thread that is locked when it is playing and unlocks when it is idle
-  stream_switcher and switch_stream switch to the weather stream when the idle thread is unlocked
- the idle weather stream only plays when a weather rtmp url is passed which is optional otherwise it just works like normal

in order for the weather stream to play make sure to loop a video using ffmpeg:
ffmpeg -re -stream_loop -1 -i videos/VIDEO_PATH.mp4 -c copy -f flv rtmp://localhost:1935/live/weather