### PR TITLE
Prevent single failed download from killing the whole download worker

### DIFF
--- a/server.py
+++ b/server.py
@@ -308,6 +308,11 @@ def download_video_worker():
                 continue
             video_path = download_video(config)
             play_video_queue.put((config, video_path))
+        except Exception as e:
+            # Never let a single failed download kill the worker thread;
+            # otherwise every subsequent video silently fails to download.
+            logging.exception(f"Failed to download video: {e}")
+            write_log_to_client(f"Failed to download video: {e}")
         finally:
             download_url_queue.task_done()
 


### PR DESCRIPTION
When download_video() raised an error for any reason (unavailable, network error, etc.) the exception propagated out of the `while True `loop and the worker thread died.

An except `Exception` block was added in the worker loop that catches any error from a single download, logs it and lets the loop continue.

Now a video that fails to download is logged and skipped. The worker thread stays alive and continues to process the rest of the queue.