### PR TITLE
Thumbnail not showing when a video is playing fix

### DIFF
--- a/server.py
+++ b/server.py
@@ -617,6 +617,8 @@ async def play(url: str, loop: bool = False, repeat: bool = False, resolution: i
             # choose the highest resolution video stream
             best = video.streams.filter(only_video=True).order_by("resolution").desc().first()
             if best and best.resolution and best.resolution.endswith("p"):
+                # best.resolution is a str ending in "p" e.g. '2160p' (or
+                # '1080p', '720p', etc.) basically the height in pixels plus a "p"
                 in_h = int(best.resolution[:-1])
                 # fall back to 16:9 if unknown
                 in_w = int(round(in_h * (16 / 9)))

--- a/server.py
+++ b/server.py
@@ -598,23 +598,30 @@ async def play(url: str, loop: bool = False, repeat: bool = False, resolution: i
         raise HTTPException(status_code=400, detail="Unknown URL")
     elif url_type == UrlType.EMPTY:
         return Response(status_code=204)
-    try: 
-        video = YouTube(url)
-    except Exception as e:
-        write_log_to_client(f"Failed to load YouTube video: {e}")
-        return {"detail": "Failed"}
     # get aspect ratio from best available video-only stream
     in_w = None
     in_h = None
-    try:
-        # choose the highest resolution video stream
-        best = video.streams.filter(only_video=True).order_by("resolution").desc().first()
-        if best and best.resolution and best.resolution.endswith("p"):
-            in_h = int(best.resolution[:-1])
-            # fall back to 16:9 if unknown
-            in_w = int(round(in_h * (16 / 9)))
-    except Exception:
-        pass
+    title = None
+    thumbnail = None
+    # Only single videos resolve to a YouTube object here; playlists are
+    # expanded into individual videos later in the pipeline.
+    if url_type == UrlType.VIDEO:
+        try:
+            video = YouTube(url)
+            title = video.title
+            thumbnail = video.thumbnail_url
+        except Exception as e:
+            write_log_to_client(f"Failed to load YouTube video: {e}")
+            return {"detail": "Failed"}
+        try:
+            # choose the highest resolution video stream
+            best = video.streams.filter(only_video=True).order_by("resolution").desc().first()
+            if best and best.resolution and best.resolution.endswith("p"):
+                in_h = int(best.resolution[:-1])
+                # fall back to 16:9 if unknown
+                in_w = int(round(in_h * (16 / 9)))
+        except Exception:
+            pass
 
     actual_size = None
     if in_w and in_h and resolution:
@@ -627,6 +634,8 @@ async def play(url: str, loop: bool = False, repeat: bool = False, resolution: i
         url_type=url_type,
         url=url,
         loop=loop,
+        title=title,
+        thumbnail=thumbnail,
         play_interlude_after=True,
         repeat=repeat,
         requested_height=int(resolution),


### PR DESCRIPTION
When you played a single YouTube video, the "NOW PLAYING" card showed only the heading and the Stop button. No title and no thumbnail.

/play now pulls the title and thumbnail from the video and passes them along when it plays.
It also only does this lookup for single videos now before, it ran for playlists too and caused playlist links to fail.

Playing a video shows its real title and thumbnail in the "NOW PLAYING" card.
